### PR TITLE
bug fix: 修复切换可见性时， 下一次的输入一定是第1个密码字符

### DIFF
--- a/library/src/main/java/com/jungly/gridpasswordview/GridPasswordView.java
+++ b/library/src/main/java/com/jungly/gridpasswordview/GridPasswordView.java
@@ -325,8 +325,14 @@ public class GridPasswordView extends LinearLayout {
      * Set the enabled state of this view.
      */
     public void setPasswordVisibility(boolean visible) {
-        for (TextView textView : viewArr)
+        for (TextView textView : viewArr){
             textView.setTransformationMethod(visible ? null : transformationMethod);
+            if(textView instanceof EditText){
+                EditText et = (EditText) textView;
+                et.setSelection(et.getText().length());
+            }
+        }
+            
     }
 
     /**


### PR DESCRIPTION
bug重现步骤：
1. 选用那个可以toggleVisiblity的GridPwdView
2. 输入"op", 再切换密码可见性的Switch或CheckBox
3. 再输入任何一个字符， 发现显示的第3个输入字符一定是“o"， 即上面我们”op“中的第一个字符

修改方案：
toggle时，将selection仍回复到最末尾